### PR TITLE
ENH - added some functions, to be able to do a 'static', i.e. non tim…

### DIFF
--- a/meg/dat2F.m
+++ b/meg/dat2F.m
@@ -1,0 +1,70 @@
+function [F, R0, R, n, p1, p2, B] = dat2F(alldat, design, col0, lambda, B)
+
+if nargin<3 || isempty(col0)
+  col0 = 1;
+end
+
+if nargin<4 || isempty(lambda)
+  lambda = 0;
+end
+
+if nargin<5
+  B = [];
+end
+
+n  = size(design,1);
+p2 = size(design,2);
+p1 = numel(col0);
+
+siz = size(alldat);
+dat = reshape(permute(alldat,[1 3 2]),[siz(1) siz(2)*siz(3)]);
+%dat = dat - nanmean(dat,1);
+%dat = normc(dat);
+design = demean(design);
+if isempty(B)
+  if ~lambda
+    B   = design\dat;
+  else
+    B   = ((design'*design+lambda.*eye(size(design,2)))\design')*dat;
+  end
+elseif iscell(B)
+  % assume that B is a cell-array containing the indices of the test-folds.
+  for k = 1:numel(B)
+    ix = B{k};
+    iy = setdiff(1:size(alldat,1),ix);
+    
+    % demean all regressors, apart from the constant one
+    design(iy,:) = demean(design(iy,:));
+    design(ix,:) = demean(design(ix,:));
+    
+    [~,  ~, ~, ~, ~, ~, Btmp] = dat2F(alldat(iy,:,:), design(iy,:), col0, lambda); 
+    [~, tmpR0, tmpR]          = dat2F(alldat(ix,:,:), design(ix,:), col0, lambda, Btmp); 
+    if k==1
+      R0 = tmpR0.*numel(ix);
+      R  =  tmpR.*numel(ix);
+      n  =        numel(ix);
+    else
+      R0 = tmpR0.*numel(ix) + R0;
+      R  = tmpR .*numel(ix) + R;
+      n  =        numel(ix) + n;
+    end
+  end
+  F = (R0-R)./R;
+  return;
+else
+  % use the pre-supplied weights
+  B = reshape(permute(B, [1 3 2]), [size(B,1) size(B,2)*size(B,3)]);
+end
+
+R0 = permute(reshape(sum((dat-design(:,col0)*B(col0,:)).^2),[siz(3) siz(2)]),[2 1]);
+R  = permute(reshape(sum((dat-design*B).^2),[siz(3) siz(2)]),[2 1]);
+
+F  = ((R0-R)./(p2-p1))./(R./(n-p2));
+B  = permute(reshape(B,[size(B,1) siz(3) siz(2)]),[1 3 2]);
+
+function out = demean(in)
+
+out = in - repmat(nanmean(in,1), size(in,1), 1);
+sel = all(sum(out==0),1);
+out(:,sel) = in(:,sel);
+

--- a/meg/vsm_extractwords.m
+++ b/meg/vsm_extractwords.m
@@ -1,0 +1,44 @@
+function [tlck, stimdata] = vsm_extractwords(subject)
+
+d           = vsm_dir();
+savedir     = d.trf;
+
+ft_hastoolbox('cellfunction', 1);
+
+meg         = fullfile(d.preproc, [subject '_lcmv-data.mat']);
+stimdata    = vsm_stimdata(subject);
+load(meg)
+
+% verify the number of trials
+if ~(numel(data.trial)==numel(stimdata))
+  error('the number of stories does not match');
+end
+
+for k = 1:numel(stimdata)
+  
+  tmp     = keepfields(data, {'label' 'grad' 'fsample'});
+  tmp.time = (-14:75)./tmp.fsample;
+  tmpstim = stimdata{k};
+  
+  start = [tmpstim.start_time];
+  sel   = isfinite(start);
+  start = start(sel);
+  tmpstim = tmpstim(sel);
+  nword = numel(tmpstim);
+  trial = nan(nword,numel(tmp.label), 90);
+  for m = 1:nword
+    ix = nearest(data.time{k}, start(m));
+    ix1 = max(1,ix-14);
+    ix2 = min(numel(data.time{k}), ix+75);
+    
+    
+    trial(m,:,1:(ix2-ix1+1)) = data.trial{k}(:,ix1:ix2); % this assumes that ix > 14 always
+  end
+  tmp.trial = trial;
+  tmp.dimord = 'rpt_chan_time';
+  
+  tlck{k} = tmp;
+  stimdata{k} = tmpstim;
+  
+  clear tmp;
+end

--- a/meg/vsm_stimdata.m
+++ b/meg/vsm_stimdata.m
@@ -1,0 +1,159 @@
+function stimdata = vsm_stimdata(subject, audiofile)
+
+% streams_preprocessing() 
+
+%% INITIALIZE
+
+if ischar(subject)
+  subject = vsm_subjinfo(subject);
+end
+audiofile = subject.audiofile;
+
+% determine the trials with which the audiofiles correspond
+seltrl   = zeros(0,1);
+selaudio = cell(0,1);
+for k = 1:numel(audiofile)
+
+  tmp = contains(subject.audiofile, audiofile{k}); % check which audiofiles were selected by the user
+  if sum(tmp)==1
+    seltrl   = cat(1, seltrl, find(tmp));
+    selaudio = cat(1, selaudio, subject.audiofile(tmp)); 
+  else
+    % file is not there
+  end
+end
+
+% deal with more than one ds-directory per subject
+if iscell(subject.dataset)
+  dataset = cell(0,1);
+  trl     = zeros(0,size(subject.trl{1},2));
+  for k = 1:numel(subject.dataset)
+    trl     = cat(1, trl, subject.trl{k});
+    dataset = cat(1, dataset, repmat(subject.dataset(k), [size(subject.trl{k},1) 1])); 
+    %mixing    = cat(1, mixing,    repmat(subject.eogv.mixing(k), [size(subject.trl{k},1) 1]));
+    %unmixing  = cat(1, unmixing,  repmat(subject.eogv.unmixing(k), [size(subject.trl{k},1) 1]));
+    %badcomps  = cat(1, badcomps,  repmat(subject.eogv.badcomps(k), [size(subject.trl{k},1) 1]));
+    
+  end
+  trl     = trl(seltrl,:);
+  dataset = dataset(seltrl);
+  %mixing  = mixing(seltrl);
+  %unmixing = unmixing(seltrl);
+  %badcomps = badcomps(seltrl);
+else
+  dataset = repmat({subject.dataset}, [numel(seltrl) 1]);
+  trl     = subject.trl(seltrl,:);
+  %mixing    = repmat({subject.eogv.mixing},   [numel(seltrl) 1]);
+  %unmixing  = repmat({subject.eogv.unmixing}, [numel(seltrl) 1]);
+  %badcomps  = repmat({subject.eogv.badcomps}, [numel(seltrl) 1]);
+
+end
+
+%% PREPROCESSING LOOP PER AUDIOFILE
+
+audiodir                    = '/project/3011044.02/lab/pilot/stim/audio';
+subtlex_table_filename      = '/project/3011044.02/raw/stimuli/worddata_subtlex.mat';
+subtlex_firstrow_filename   = '/project/3011044.02/raw/stimuli/worddata_subtlex_firstrow.mat';
+subtlex_data     = [];          % declare the variables, it throws a dynamic assignment error otherwise
+subtlex_firstrow = [];
+
+% load in the files that contain word frequency information
+load(subtlex_firstrow_filename);
+load(subtlex_table_filename);
+
+stimdata = cell(numel(seltrl),1);
+for k = 1:numel(seltrl)
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%
+  % LANGUAGE PREPROCESSING %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%
+  
+  [~,f,~] = fileparts(selaudio{k});
+  
+  % create combineddata data structure
+  dondersfile  = fullfile(audiodir, f, [f,'.donders']);
+  textgridfile = fullfile(audiodir, f, [f,'.TextGrid']);
+  combineddata = combine_donders_textgrid(dondersfile, textgridfile);
+  
+  % Compute word duration
+  for i = 1:numel(combineddata)
+    
+    if ~isempty(combineddata(i).start_time)
+      combineddata(i).duration = combineddata(i).end_time - combineddata(i).start_time;
+    else
+      combineddata(i).duration = nan;
+    end
+  end
+  
+  % add .iscontent field to combineddata structure
+  combineddata = streams_combinedata_iscontent(combineddata);
+  
+  % add subtlex frequency info and word length
+  combineddata = add_subtlex(combineddata, subtlex_data,  subtlex_firstrow);
+  
+  % create semantic distance field in combineddata
+  vector_file        = fullfile('/project/3011044.02/preproc/stimuli/vectors', [f '.txt']);
+  [vecmat, words]    = vsm_readvectors(vector_file);
+  
+  vec2dist_selection = [combineddata(:).iscontent]';
+  
+  cfg           = [];
+  cfg.words     = words;                    % cell array of word strings
+  cfg.word_idx  = [combineddata(:).word_]'; % word indices of word positions in a sentence
+  cfg.context   = 'moving_window';
+  cfg.order     = 5;
+  cfg.selection = vec2dist_selection;
+  
+  d1       = vsm_vec2dist(cfg, vecmat);
+  
+  cfg.context   = 'sentence';
+  d2      = vsm_vec2dist(cfg, vecmat);
+  
+  for jj = 1:numel(words)
+    combineddata(jj).embedding = vecmat(jj,:)'; % pick the vector row for this word, store as column
+    combineddata(jj).semdist1  = d1(jj);        % semantic distance based on moving window
+    combineddata(jj).semdist2  = d2(jj);        % semantic distance based on average across sentence
+  end
+  
+  % create language predictor based on language model output
+  
+  stimdata{k} = combineddata;
+  
+end
+
+% ADD SUBTLEX INFORMATION 
+function [combineddata] = add_subtlex(combineddata, subtlex_data, subtlex_firstrow)
+
+num_words = size(combineddata, 1);
+
+word_column         = strcmp(subtlex_firstrow, 'spelling');
+wlen_column         = strcmp(subtlex_firstrow, 'nchar');
+frequency_column    = strcmp(subtlex_firstrow, 'Lg10WF');
+
+subtlex_words = subtlex_data(:, word_column);
+
+    % add frequency information to combineddata structure
+    for j = 1:num_words
+
+        word = combineddata(j).word;
+        word = word{1};
+        row = find(strcmp(subtlex_words, word)); % find the row index in subtlex data
+
+        if ~isempty(row) 
+            
+             combineddata(j).log10wf = subtlex_data{row, frequency_column}; % lookup the according frequency values
+             combineddata(j).nchar   = subtlex_data{row, wlen_column};
+             
+        else % write 'nan' if it is a punctuation mark or a proper name (subtlex doesn't give values in this case)
+            
+            combineddata(j).log10wf = nan;
+            combineddata(j).nchar   = nan;
+            
+        end
+
+    end
+    
+end
+
+end
+ 


### PR DESCRIPTION
…e-shifted regression, possibly more suitable for 'stick' like regressors

To be used as:

[tlck,stimdata]=vsm_extractwords('s04');

This gives a set of 'tlck' structures, with the data reorganized to be word x parcel/channel x time, per story

And a cell-array of stimdata, with per word information.

Next one could do something like

design = cat(2,stimdata{x}.embedding)';
design = [ones(size(design,1)) design-mean(design)];

F = dat2F(tlck{x}.trial,design);

dat2F is a bit ugly still, and computes some regression based quantities, optionally by means of a regularised regression, using cross-validation. (if it's done per cross validation, the F is not a proper F statistic but a ratio of R-squared values). In any case, the F-statistic (or R-ratio) is based on  a model comparison, where two models are compared, one based on design(:,col0) and the other on the full design. One typical application I can think of, would be to compare how adding a feature (e.g. embedding) improves the signal 'prediction' beyond the word-based average (hence the constant term added to the design).